### PR TITLE
Handle debounce in I2CKeypad_interrupts_1 example

### DIFF
--- a/examples/I2CKeypad_interrupts_1/I2CKeypad_interrupts_1.ino
+++ b/examples/I2CKeypad_interrupts_1/I2CKeypad_interrupts_1.ino
@@ -80,6 +80,8 @@ void setup()
     while (1);
   }
 
+  keyPad.setDebounceThreshold(50);
+
   measurePolling();
 }
 
@@ -89,6 +91,9 @@ void loop()
   if (keyChange)
   {
     uint8_t index = keyPad.getKey();
+    //  ignore key bounces
+    if (index == I2C_KEYPAD_THRESHOLD)
+        return;
     //  only after keyChange is handled it is time reset the flag
     keyChange = false;
     if (index != 16)


### PR DESCRIPTION
Hi, The example code in *I2CKeypad_interrupts_1.ino* has a potential bug. The `loop()` function doesn't handle the case where `getKey()` returns `I2C_KEYPAD_THRESHOLD` (255). Instead, it uses the number 255 as an index into an array of 19 bytes. That's an invalid memory access. To fix it, the following should be added after the call to getKey().

    if (index == I2C_KEYPAD_THRESHOLD)
        return;

Perhaps it's not really a bug since it doesn't call the new `setDebounceThreshold()` method, but this pull request does that as well. It might not strictly be necessary for this example, but I think it makes it a better example.